### PR TITLE
Deterministic Resets

### DIFF
--- a/kernel/sched/Makefile
+++ b/kernel/sched/Makefile
@@ -13,6 +13,8 @@ KCOV_INSTRUMENT := n
 KCSAN_SANITIZE := n
 KCSAN_INSTRUMENT_BARRIERS := y
 
+KASAN_SANITIZE := n
+
 ifneq ($(CONFIG_SCHED_OMIT_FRAME_POINTER),y)
 # According to Alan Modra <alan@linuxcare.com.au>, the -fno-omit-frame-pointer is
 # needed for x86 only.  Why this used to be enabled for all architectures is beyond

--- a/tools/sched_ext/pct.c
+++ b/tools/sched_ext/pct.c
@@ -1,0 +1,246 @@
+
+/*
+ * Variables for PCT implementation
+ *
+ * The following variables are set in the corresponding C program
+ * based on user-defined parameters.
+ * 
+ * @depth: the depth of the concurrency bug to find (i.e., the number of
+ * 	   interleavings that would trigger the bug)
+ * @use_pct: flag to indicate whether to use PCT
+ */ 
+
+const volatile u32 depth = 3;
+u32 strata;
+
+/*
+ * Map to store the pre-determined priorities for each thread.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, MAX_THREADS);
+} pct_priorities SEC(".maps");
+
+/* Swaps two elements in an array */
+static inline void swap(u32 *a, u32 *b)
+{
+	u32 temp = *a;
+	*a = *b;
+	*b = temp;
+}
+
+
+/* Get strata base for PCT */
+inline s32 get_strata_base()
+{
+	return S32_MAX - ((strata + 2) * MAX_THREADS);
+}
+/* 
+ * Assign the priority for a thread based on the pre-determined priorities
+ * in the pct_priorities map.
+ * 
+ * We use % MAX_THREADS to ensure that the index is within the range of the
+ * map, and also allow for subsequent processes to get different priorities.
+ */
+s32 assign_pct_priority(pid_t pid)
+{
+	u32 index = (u32)pid % MAX_THREADS;
+	s32 *prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
+	if (prio_value)
+		return *prio_value;
+
+	return -1;
+}
+
+/*
+ * Update the priority of a thread in the pct_priorities map.
+ */
+static void update_pct_priority(pid_t pid, s32 new_prio)
+{
+	u32 index = (u32)pid % MAX_THREADS;
+	u32 *prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
+	if (prio_value)
+		*prio_value = new_prio;
+}
+
+/*
+ * Map to store the pre-determined change points for each iteration.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries,
+	       MAX_THREADS); // should be depth - 1 tho, but this needs a constant
+} pct_change_points SEC(".maps");
+
+
+/* 
+ * Shuffle the priorities in the pct_priorities map. This function is called
+ * during init() of the scheduler, and after each iteration.
+ */
+static void shuffle_prios(struct xorshift32_state *state)
+{
+	u32 *prio_value, *value_i, *value_j;
+	u32 index, i, actual_i, actual_j;
+
+	/* Reset the priorities for the new iteration */
+	bpf_for(i, depth, depth + MAX_THREADS)
+	{
+		index = i - depth;
+		prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
+		if (prio_value)
+			*prio_value = get_strata_base() + i;
+	}
+
+	/* Shuffle the resetted priorities using Fisher–Yates algorithm */
+	bpf_for(i, 1, MAX_THREADS)
+	{
+		actual_i = MAX_THREADS - i;
+		actual_j = xorshift32(state) % actual_i;
+		value_i = bpf_map_lookup_elem(&pct_priorities, &actual_i);
+		value_j = bpf_map_lookup_elem(&pct_priorities, &actual_j);
+		if (value_i && value_j) {
+			swap(value_i, value_j);
+		} else {
+			warn("[shuffle_prios] failed to swap values at index: %d and %d\n",
+			     actual_i, actual_j);
+		}
+	}
+}
+
+/*
+ * Choose the change points for the next iteration. This function is called
+ * during init() of the scheduler, and after each iteration.
+ */
+static void choose_change_points(struct xorshift32_state *state)
+{
+	/* 
+	 * This occurs in a multi-process environment, where the main threads
+	 * of each process exit one after another, with no enqueue()s called
+	 * in between.
+	 */
+	if (max_num_events == 0) {
+		/*
+		 * If no events have occurred for the prev iteration, we don't make
+		 * any assumptions about num_events and set the change points to 1, 
+		 * 2, ... for the next iteration. TODO: this may not be the best approach.
+		 */
+		u32 i, n = depth - 1;
+		bpf_for(i, 0, n)
+		{
+			u32 change_point = i;
+			long status = bpf_map_update_elem(
+				&pct_change_points, &i, &change_point, BPF_ANY);
+			if (status)
+				warn("[choose_change_points] failed to update change_point[%d]: %d\n",
+				     i, change_point);
+		}
+		return;
+	}
+
+	u32 i, n, change_point;
+	long status;
+
+	n = depth - 1;
+	if (n > MAX_THREADS) {
+		scx_bpf_error("[choose_change_points] n: %d, MAX_THREADS: %d\n",
+			      n, MAX_THREADS);
+		return;
+	}
+
+	bpf_for(i, 0, n)
+	{
+		/* NOTE: THERE MAY BE DUPLICATE CHANGE POINTS */
+		change_point = (xorshift32(state) % max_num_events) +
+			       1; // [1, max_num_events]
+		status = bpf_map_update_elem(&pct_change_points, &i,
+					     &change_point, BPF_ANY);
+		if (status)
+			warn("[choose_change_points] failed to update change_point[%d]: %d\n",
+			     i, change_point);
+
+		dbg("[choose_change_points] change_point[%d]: %d\n", i,
+		    change_point);
+	}
+}
+
+s32 init_pct() {
+	/* Initialise PCT variables */
+	if (use_pct) {
+		dbg("[init] depth: %d\n", depth);
+		iterations = 0;
+		max_num_events = 0;
+		strata = 0;
+		initial_max_num_events = depth * 10;
+		task_count = 0;
+		num_events = 0;
+		shuffle_prios(&rng_state);
+		choose_change_points(&rng_state);
+		strata = 0;
+	}
+	return 0;
+}
+
+static s32 update_priorities_pct(pid_t pid) {
+	s32 priority = -1;
+	/* 
+	 * For PCT, check if a change_point is incurred. If so, update the
+	 * priority of the task.
+	 */
+		u32 n = depth - 1, i;
+
+		if (n > MAX_THREADS) {
+			warn("[enqueue] n: %d, MAX_THREADS: %d\n", n,
+			     MAX_THREADS);
+			return -1;
+		}
+
+		bpf_for(i, 0, n)
+		{
+			u32 *change_point =
+				bpf_map_lookup_elem(&pct_change_points, &i);
+			if (change_point) {
+				// dbg("[enqueue] %d until change \n",
+				//     *change_point - (num_events %
+				// 		     initial_max_num_events));
+				if ((num_events % initial_max_num_events) ==
+				    *change_point) {
+					// If we have observed more events than expected, resume PCT with a
+					// new "strata" -- this allows for threads set to low priority to recover
+					if (num_events >
+					    initial_max_num_events *
+						    (strata + 1)) {
+						strata += 1;
+						dbg("[enqueue] NEW STRATA %d\n",
+						    strata);
+					}
+
+					priority = get_strata_base() + i + 1;
+					update_pct_priority(pid, priority);
+					dbg("[enqueue] UPDATE pid: %d, priority: %d\n",
+					    pid, priority);
+					break;
+				}
+			}
+		}
+
+		/* Assign priority to the task based on scheduling algo */
+		priority = assign_pct_priority(pid);
+		if (priority < 0) {
+			warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
+			     pid, priority);
+			return -1;
+		}
+
+		/*
+		 * Update the task context.
+		 *
+		 * Since we cannot assure that the task should exist (as new tasks may
+		 * get enqueued), we set should_exist to false.
+		 */
+		tctx_map_insert(pid, priority, true, false);
+}
+

--- a/tools/sched_ext/random-priority.c
+++ b/tools/sched_ext/random-priority.c
@@ -1,0 +1,32 @@
+
+/* 
+ * Random Priority Walk implementation. @use_random_walk is set in the corresponding
+ * C program based on user-defined parameters.
+ */
+
+/*
+ * Assign the priority for a thread based on a completely random number.
+ */
+static inline int update_priorities_rp(pid_t pid)
+{
+	s32 priority = xorshift32(&rng_state) % 2147483647;
+	dbg("prio new %d", priority);
+
+	if (priority < 0) {
+		warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
+		     pid, priority);
+		return -1;
+	}
+
+	/*
+	 * Update the task context.
+	 *
+	 * Since we cannot assure that the task should exist (as new tasks may
+	 * get enqueued), we set should_exist to false.
+	 */
+	tctx_map_insert(pid, priority, true, false);
+}
+
+static inline s32 init_rp() {
+	  return 0;
+}

--- a/tools/sched_ext/random-walk.c
+++ b/tools/sched_ext/random-walk.c
@@ -1,0 +1,69 @@
+
+/* 
+ * Random Walk implementation. @use_random_walk is set in the corresponding
+ * C program based on user-defined parameters.
+ */
+
+/*
+ * Assign the priority for a thread based on a completely random number.
+ */
+static inline s32 assign_rw_priority()
+{
+	s32 priority = xorshift32(&rng_state) % 2147483647;
+	dbg("prio new %d", priority);
+	return priority;
+}
+
+
+/*
+ * Callback function to update all priorities in tctx_map for random_walk_2
+ */
+static __u64 update_all_prios(struct bpf_map *map, pid_t *key,
+			      struct task_ctx *tctx,
+			      struct tctx_callback_ctx *tcallbackctx)
+{
+	/* Use highest_priority_pid to indicate the pid of the task we have already updated */
+	pid_t pid_to_avoid = tcallbackctx->highest_priority_pid;
+	s32 new_priority;
+	if (*key != pid_to_avoid) {
+		new_priority = assign_rw_priority();
+		bpf_spin_lock(&tctx->lock);
+		tctx->priority = new_priority;
+		bpf_spin_unlock(&tctx->lock);
+	}
+	return 0;
+}
+
+static s32 update_priorities_rw(pid_t pid) {
+		s32 priority = assign_rw_priority();
+
+		if (priority < 0) {
+			warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
+			     pid, priority);
+			return -1;
+		}
+
+		/*
+		 * Update the task context.
+		 *
+		 * Since we cannot assure that the task should exist (as new tasks may
+		 * get enqueued), we set should_exist to false.
+		 */
+		tctx_map_insert(pid, priority, true, false);
+
+		/* Update the priorities of all threads */
+		struct tctx_callback_ctx tcallbackctx = {
+			.highest_priority_pid = pid,
+		};
+
+		bpf_for_each_map_elem(&task_ctx_map, update_all_prios,
+				      &tcallbackctx, 0);
+
+		return 0;
+}
+
+static inline s32 init_rw() {
+	  return 0;
+}
+
+

--- a/tools/sched_ext/scx_scheduling_algorithms.c
+++ b/tools/sched_ext/scx_scheduling_algorithms.c
@@ -1,0 +1,39 @@
+
+/* The following variables are set by the BPF program.
+ * 
+ * @iterations: the number of times the main thread has exited
+ * @max_num_events: the maximum number of enqueue()s that have occurred
+ * 		over one iteration. 
+ * @num_events: the number of enqueue()s that have occurred
+ */
+
+u32 iterations, initial_max_num_events, task_count, max_num_events,
+	num_events;
+
+#include "pct.c"
+#include "random-walk.c"
+#include "random-priority.c"
+
+s32 update_priorities(pid_t pid) {
+	if (use_pct) {
+		return update_priorities_pct(pid);
+	} else if (use_random_walk) {
+		return update_priorities_rw(pid);			
+	} else if (use_random_priority_walk) {
+		return update_priorities_rp(pid);
+	}
+
+	return -1;
+}
+
+int init_scheduling_algo() {
+	if (use_pct) {
+		return init_pct();
+	} else if (use_random_walk) {
+		return init_rw();			
+	} else if (use_random_priority_walk) {
+		return init_rp();
+	}
+
+	return -1;
+}

--- a/tools/sched_ext/scx_serialise.bpf.c
+++ b/tools/sched_ext/scx_serialise.bpf.c
@@ -66,7 +66,7 @@ struct {
  */
 struct task_ctx {
 	s32 priority;
-	u32 id; // id of executor
+	u32 eid; // id of executor
 	bool enqueued;
 	struct bpf_spin_lock lock;
 };
@@ -190,7 +190,7 @@ static int tctx_map_insert(pid_t new_pid, s32 modify_prio, bool enqueued,
 	/* Update priority and enqueued status */
 	bpf_spin_lock(&tctx->lock);
 	if (modify_prio)
-		tctx->priority = modify_prio;
+	tctx->priority = modify_prio;
 	tctx->enqueued = enqueued;
 	bpf_spin_unlock(&tctx->lock);
 

--- a/tools/sched_ext/scx_serialise.bpf.c
+++ b/tools/sched_ext/scx_serialise.bpf.c
@@ -24,6 +24,7 @@ UEI_DEFINE(uei);
  */
 #define MAX_THREADS 50
 
+const volatile u32 seed = 0xdeadbeef;
 
 /* xorshift random generator */
 struct xorshift32_state rng_state;
@@ -63,7 +64,6 @@ struct {
  * each task. These variables are protected by a spin lock to sieve out
  * concurrent updates.
  */
-
 struct task_ctx {
 	s32 priority;
 	u32 id; // id of executor
@@ -84,17 +84,6 @@ struct {
 	__type(value, struct task_ctx);
 	__uint(max_entries, MAX_THREADS);
 } task_ctx_map SEC(".maps");
-
-static int insert_task_ctx_map(pid_t pid, u32 eid, bool enqueued)
-{
-	struct task_ctx ctx;
-	ctx.id = eid;
-	ctx.enqueued = enqueued;
-	if (bpf_map_update_elem(&task_ctx_map, &pid, &ctx, BPF_NOEXIST) < 0) {
-		bpf_printk("[insert_task_ctx_map] task context alredy exists");
-	}
-	return 0;
-}
 
 /*
  * Dispatch statistics. This map is used to keep track of the number of times
@@ -358,241 +347,17 @@ static inline bool is_sched_ext(const struct task_struct *p)
 	return policy == SCHED_EXT;
 }
 
-/*
- * Variables for PCT implementation
- *
- * The following variables are set in the corresponding C program
- * based on user-defined parameters.
- * 
- * @depth: the depth of the concurrency bug to find (i.e., the number of
- * 	   interleavings that would trigger the bug)
- * @seed: the seed for the random number generator
- * @use_pct: flag to indicate whether to use PCT
- * 
- * The following variables are set by the BPF program.
- * 
- * @iterations: the number of times the main thread has exited
- * @max_num_events: the maximum number of enqueue()s that have occurred
- * 		over one iteration. 
- * @num_events: the number of enqueue()s that have occurred
- */
-const volatile u32 depth = 3, seed = 0xdeadbeef;
-const volatile int use_pct = 0;
-u32 iterations, initial_max_num_events, task_count, strata, max_num_events,
-	num_events;
-
-
-/*
- * Map to store the pre-determined priorities for each thread.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries, MAX_THREADS);
-} pct_priorities SEC(".maps");
-
-/* Swaps two elements in an array */
-static inline void swap(u32 *a, u32 *b)
-{
-	u32 temp = *a;
-	*a = *b;
-	*b = temp;
-}
-
-/* Get strata base for PCT */
-inline s32 get_strata_base()
-{
-	return S32_MAX - ((strata + 2) * MAX_THREADS);
-}
-
-/* 
- * Shuffle the priorities in the pct_priorities map. This function is called
- * during init() of the scheduler, and after each iteration.
- */
-static void shuffle_prios(struct xorshift32_state *state)
-{
-	u32 *prio_value, *value_i, *value_j;
-	u32 index, i, actual_i, actual_j;
-
-	/* Reset the priorities for the new iteration */
-	bpf_for(i, depth, depth + MAX_THREADS)
-	{
-		index = i - depth;
-		prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
-		if (prio_value)
-			*prio_value = get_strata_base() + i;
-	}
-
-	/* Shuffle the resetted priorities using Fisher–Yates algorithm */
-	bpf_for(i, 1, MAX_THREADS)
-	{
-		actual_i = MAX_THREADS - i;
-		actual_j = xorshift32(state) % actual_i;
-		value_i = bpf_map_lookup_elem(&pct_priorities, &actual_i);
-		value_j = bpf_map_lookup_elem(&pct_priorities, &actual_j);
-		if (value_i && value_j) {
-			swap(value_i, value_j);
-		} else {
-			warn("[shuffle_prios] failed to swap values at index: %d and %d\n",
-			     actual_i, actual_j);
-		}
-	}
-}
-
-/* 
- * Assign the priority for a thread based on the pre-determined priorities
- * in the pct_priorities map.
- * 
- * We use % MAX_THREADS to ensure that the index is within the range of the
- * map, and also allow for subsequent processes to get different priorities.
- */
-s32 assign_pct_priority(pid_t pid)
-{
-	u32 index = (u32)pid % MAX_THREADS;
-	s32 *prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
-	if (prio_value)
-		return *prio_value;
-
-	return -1;
-}
-
-/*
- * Update the priority of a thread in the pct_priorities map.
- */
-static void update_pct_priority(pid_t pid, s32 new_prio)
-{
-	u32 index = (u32)pid % MAX_THREADS;
-	u32 *prio_value = bpf_map_lookup_elem(&pct_priorities, &index);
-	if (prio_value)
-		*prio_value = new_prio;
-}
-
-/*
- * Map to store the pre-determined change points for each iteration.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
-	__type(value, u32);
-	__uint(max_entries,
-	       MAX_THREADS); // should be depth - 1 tho, but this needs a constant
-} pct_change_points SEC(".maps");
-
-/*
- * Choose the change points for the next iteration. This function is called
- * during init() of the scheduler, and after each iteration.
- */
-static void choose_change_points(struct xorshift32_state *state)
-{
-	/* 
-	 * This occurs in a multi-process environment, where the main threads
-	 * of each process exit one after another, with no enqueue()s called
-	 * in between.
-	 */
-	if (max_num_events == 0) {
-		/*
-		 * If no events have occurred for the prev iteration, we don't make
-		 * any assumptions about num_events and set the change points to 1, 
-		 * 2, ... for the next iteration. TODO: this may not be the best approach.
-		 */
-		u32 i, n = depth - 1;
-		bpf_for(i, 0, n)
-		{
-			u32 change_point = i;
-			long status = bpf_map_update_elem(
-				&pct_change_points, &i, &change_point, BPF_ANY);
-			if (status)
-				warn("[choose_change_points] failed to update change_point[%d]: %d\n",
-				     i, change_point);
-		}
-		return;
-	}
-
-	u32 i, n, change_point;
-	long status;
-
-	n = depth - 1;
-	if (n > MAX_THREADS) {
-		scx_bpf_error("[choose_change_points] n: %d, MAX_THREADS: %d\n",
-			      n, MAX_THREADS);
-		return;
-	}
-
-	bpf_for(i, 0, n)
-	{
-		/* NOTE: THERE MAY BE DUPLICATE CHANGE POINTS */
-		change_point = (xorshift32(state) % max_num_events) +
-			       1; // [1, max_num_events]
-		status = bpf_map_update_elem(&pct_change_points, &i,
-					     &change_point, BPF_ANY);
-		if (status)
-			warn("[choose_change_points] failed to update change_point[%d]: %d\n",
-			     i, change_point);
-
-		dbg("[choose_change_points] change_point[%d]: %d\n", i,
-		    change_point);
-	}
-}
-
-/* 
- * Random Walk implementation. @use_random_walk is set in the corresponding
- * C program based on user-defined parameters.
- */
-const volatile int use_random_walk = 0;
-const volatile int use_random_walk_2 = 1;
-
-/*
- * Assign the priority for a thread based on a completely random number.
- */
-static inline s32 assign_rw_priority(pid_t pid)
-{
-	s32 priority = xorshift32(&rng_state) % 2147483647;
-	dbg("prio new %d", priority);
-	return priority;
-}
-
-/* 
- * Combines all implemented scheduling algorithms and chooses
- * the appropriate priority to assign to a thread.
- */
-s32 assign_priority(pid_t pid)
-{
-	if (use_random_walk || use_random_walk_2)
-		return assign_rw_priority(pid);
-
-	if (use_pct)
-		return assign_pct_priority(pid);
-
-	/* should not reach here */
-	scx_bpf_error(
-		"[assign_priority] ERROR: no scheduling algorithm chosen\n");
-	return -2;
-}
-
-/*
- * Callback function to update all priorities in tctx_map for random_walk_2
- */
-static __u64 update_all_prios(struct bpf_map *map, pid_t *key,
-			      struct task_ctx *tctx,
-			      struct tctx_callback_ctx *tcallbackctx)
-{
-	/* Use highest_priority_pid to indicate the pid of the task we have already updated */
-	pid_t pid_to_avoid = tcallbackctx->highest_priority_pid;
-	s32 new_priority;
-	if (*key != pid_to_avoid) {
-		new_priority = assign_priority(*key);
-		bpf_spin_lock(&tctx->lock);
-		tctx->priority = new_priority;
-		bpf_spin_unlock(&tctx->lock);
-	}
-	return 0;
-}
-
 // static __u64 dump_error(struct bpf_map *map, pid_t *key, struct task_ctx *tctx, struct tctx_callback_ctx *tcallbackctx) {
 //     dbg("[dump_error] pid: %d, priority: %d, enqueued: %d\n", *key, tctx->priority, tctx->enqueued);
 //     return 0;
 // }
+
+const volatile int use_pct = 0;
+const volatile int use_random_priority_walk = 0;
+const volatile int use_random_walk = 1;
+
+#include "scx_scheduling_algorithms.c"
+
 
 static u32 get_executor_id(const struct task_struct *p) {
 	char comm[TASK_COMM_LEN];
@@ -610,6 +375,7 @@ static u32 get_executor_id(const struct task_struct *p) {
 	return eid;
 }
 
+
 /*
  * Task @p becomes ready to run. We update the task's priority and 
  * the task context to indicate that the task is enqueued.
@@ -620,8 +386,9 @@ void BPF_STRUCT_OPS(serialise_enqueue, struct task_struct *p, u64 enq_flags)
 	u32 eid;
 	struct event *e;
 
-	bpf_printk("[bpf_ringbuf_submit] PREDRIAN pid: %d\n", p->pid);
 	if (is_sched_ext(p) && (bpf_user_ringbuf_drain(&user_ringbuf, receive_req, NULL, 0) > 0)) {
+		init_scheduling_algo();
+
 		e = bpf_ringbuf_reserve(&kernel_ringbuf, sizeof(*e), 0);
 		if (e) {
 			e->pid = p->pid;
@@ -633,12 +400,10 @@ void BPF_STRUCT_OPS(serialise_enqueue, struct task_struct *p, u64 enq_flags)
 
 	if (is_sched_ext(p)) {
 		eid = get_executor_id(p);
-		insert_task_ctx_map(p->pid, eid, false);
 		// Start scheduling if condition is satisfied
-	}
+	} 
 
-	dbg("[enqueue] pid: %d, tgid: %d, enq_flags: %d\n", pid, tgid,
-	    enq_flags);
+	dbg("[enqueue] pid: %d, tgid: %d, enq_flags: %d\n", pid, tgid, enq_flags);
 
 	// READ TASK SLICE
 	// Is there something on the task struct that will tell us we are in a spin lock?
@@ -674,76 +439,7 @@ void BPF_STRUCT_OPS(serialise_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 	}
 
-	s32 priority = -1;
-
-	/* 
-	 * For PCT, check if a change_point is incurred. If so, update the
-	 * priority of the task.
-	 */
-	if (use_pct) {
-		u32 n = depth - 1, i;
-
-		if (n > MAX_THREADS) {
-			warn("[enqueue] n: %d, MAX_THREADS: %d\n", n,
-			     MAX_THREADS);
-			return;
-		}
-
-		bpf_for(i, 0, n)
-		{
-			u32 *change_point =
-				bpf_map_lookup_elem(&pct_change_points, &i);
-			if (change_point) {
-				// dbg("[enqueue] %d until change \n",
-				//     *change_point - (num_events %
-				// 		     initial_max_num_events));
-				if ((num_events % initial_max_num_events) ==
-				    *change_point) {
-					// If we have observed more events than expected, resume PCT with a
-					// new "strata" -- this allows for threads set to low priority to recover
-					if (num_events >
-					    initial_max_num_events *
-						    (strata + 1)) {
-						strata += 1;
-						dbg("[enqueue] NEW STRATA %d\n",
-						    strata);
-					}
-
-					priority = get_strata_base() + i + 1;
-					update_pct_priority(pid, priority);
-					dbg("[enqueue] UPDATE pid: %d, priority: %d\n",
-					    pid, priority);
-					break;
-				}
-			}
-		}
-	}
-
-	/* Assign priority to the task based on scheduling algo */
-	priority = assign_priority(pid);
-	if (priority < 0) {
-		warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
-		     pid, priority);
-		return;
-	}
-
-	/*
-	 * Update the task context.
-	 *
-	 * Since we cannot assure that the task should exist (as new tasks may
-	 * get enqueued), we set should_exist to false.
-	 */
-	tctx_map_insert(pid, priority, true, false);
-
-	if (use_random_walk_2) {
-		/* Update the priorities of the rest of the threads as well */
-		struct tctx_callback_ctx tcallbackctx = {
-			.highest_priority_pid = pid,
-		};
-
-		bpf_for_each_map_elem(&task_ctx_map, update_all_prios,
-				      &tcallbackctx, 0);
-	}
+	update_priorities(pid);
 }
 
 /*
@@ -954,61 +650,15 @@ void BPF_STRUCT_OPS(serialise_exit_task, struct task_struct *p,
 	} else if (!is_root_proc) {
 		dbg("[exit_task] VANILLA PROCESS pid: %d, tgid: %d, ppid: %d\n",
 		    p->pid, p->tgid, ppid);
-
-		/* required for syzkaller */
-		if (use_pct) {
-			__sync_fetch_and_add(&iterations, 1);
-
-			/* 
-			 * Update max_num_events if num_events is larger or somewhat smaller 
-			 * 20 is an arbitrary number chosen. Can be changed.
-			 */
-			if (num_events > max_num_events) {
-				max_num_events = num_events;
-			} else if (num_events < max_num_events - 20) {
-				max_num_events = num_events;
-			}
-
-			dbg("[exit_task] iterations: %d, max_num_events: %d\n",
-			    iterations, max_num_events);
-
-			initial_max_num_events = max_num_events;
-			num_events = 0;
-			strata = 0;
-
-			shuffle_prios(&rng_state);
-			choose_change_points(&rng_state);
-		}
-
 	} else {
 		dbg("[exit_task] ROOT PROCESS pid: %d, tgid: %d, ppid: %d\n",
 		    p->pid, p->tgid, ppid);
-		task_count = 0;
-
-		if (use_pct) {
-			__sync_fetch_and_add(&iterations, 1);
-
-			/* 
-			 * Update max_num_events if num_events is larger or somewhat smaller 
-			 * 20 is an arbitrary number chosen. Can be changed.
-			 */
-			if (num_events > max_num_events) {
-				max_num_events = num_events;
-			} else if (num_events < max_num_events - 20) {
-				max_num_events = num_events;
-			}
-
-			dbg("[exit_task] iterations: %d, max_num_events: %d\n",
-			    iterations, max_num_events);
-
-			initial_max_num_events = max_num_events;
-			num_events = 0;
-			strata = 0;
-
-			shuffle_prios(&rng_state);
-			choose_change_points(&rng_state);
-		}
 	}
+
+	dbg("[exit_task] max_num_events: %d\n", max_num_events);
+
+	initial_max_num_events = max_num_events;
+	num_events = 0;
 }
 
 /*
@@ -1027,18 +677,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(serialise_init)
 	}
 
 	rng_state.a = seed;
-	/* Initialise PCT variables */
-	if (use_pct) {
-		dbg("[init] depth: %d, seed: %d\n", depth, seed);
-		iterations = 0;
-		max_num_events = 0;
-		strata = 0;
-		initial_max_num_events = depth * 10;
-		task_count = 0;
-		num_events = 0;
-		shuffle_prios(&rng_state);
-		choose_change_points(&rng_state);
-	}
 
 	return 0;
 }

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -6,12 +6,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <pthread.h>
 #include <unistd.h>
 
-struct xorshift32_state {
-	u32 a;
-};
-
+#include "scx_simple_signal.h"
 #include "scx_serialise.bpf.skel.h"
 
 const char help_fmt[] =
@@ -27,6 +27,22 @@ const char help_fmt[] =
 	"  -r            (PCT disabled) 1 for random priority walk, 2 for random walk 2, Default: 2. \n"
 	"  -u            Use udelay. 0 for no, 1 for yes. (Deprecated) Default: 0.\n";
 
+
+#define SCHED_SHM "/sched_shared_memory"
+#define SHM_SIZE 1024
+
+typedef struct {
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	int available;
+	int num_call;
+	unsigned long long pid;
+} sched_shm;
+
+static int schedShmFd;
+
+sched_shm *shm_ptr;
+
 static volatile int exit_req;
 
 static void sigint_handler(int simple)
@@ -37,6 +53,74 @@ static void sigint_handler(int simple)
 // static __u64 random_number(__u64 min_num, __u64 max_num) {
 //     return (rand() % (max_num - min_num + 1)) + min_num;
 // }
+
+
+
+static void setup_shm()
+{
+	schedShmFd = shm_open(SCHED_SHM, O_CREAT | O_RDWR, 0666);
+	if (schedShmFd < 0) {
+		fprintf(stderr, "shm_open(SCHED_SHM,  O_CREAT | O_RDWR, 0666) fail");
+		exit(1);
+
+	}
+
+	if (ftruncate(schedShmFd, SHM_SIZE) < 0) {
+		fprintf(stderr, "ftruncate(schedShmFd, SHM_SIZE) fail");
+		exit(1);
+	};
+
+	shm_ptr = (sched_shm *)mmap(0, SHM_SIZE, PROT_READ | PROT_WRITE,
+				    MAP_SHARED, schedShmFd, 0);
+	if (shm_ptr == MAP_FAILED) {
+		fprintf(stderr, "mmap shm_ptr fail");
+		exit(1);
+	}
+
+	fprintf(stderr, "MEMSET\n");
+	memset(shm_ptr, 0, SHM_SIZE);
+
+	pthread_mutexattr_t mutex_attr;
+	pthread_mutexattr_init(&mutex_attr);
+	pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
+	pthread_mutex_init(&shm_ptr->mutex, &mutex_attr);
+
+	pthread_condattr_t cond_attr;
+	pthread_condattr_init(&cond_attr);
+	pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
+	pthread_cond_init(&shm_ptr->cond, &cond_attr);
+
+	pthread_mutexattr_destroy(&mutex_attr);
+	pthread_condattr_destroy(&cond_attr);
+
+	shm_ptr->available = 0;
+}
+
+static int send_sched_req(struct user_ring_buffer *ringbuf)
+{
+	int err = 0;
+	struct sched_req *req;
+
+	req = user_ring_buffer__reserve(ringbuf, sizeof(*req));
+	if (!req) {
+		err = -errno;
+		return err;
+	}
+
+	req->num_call = shm_ptr->num_call;
+	req->pid = shm_ptr->pid;
+	user_ring_buffer__submit(ringbuf, req);
+	printf("[send_sched_req] sched request has been sent\n");
+	return 0;
+}
+
+static int handle_kernel_reply(void *ctx, void *data, size_t data_sz)
+{
+	struct event *e = (struct event*)data;
+	printf("[handle_kernel_event] e->pid: %d\n", e->pid);
+	return 0;
+}
+
 
 static void read_stats(struct scx_serialise *skel, __u64 *stats)
 {
@@ -139,3 +223,19 @@ int main(int argc, char **argv)
 	scx_serialise__destroy(skel);
 	return 0;
 }
+
+
+
+// cleanup:
+// 	// /* Clean up */
+// 	munmap(shm_ptr, SHM_SIZE);
+//     close(schedShmFd);
+
+// 	ring_buffer__free(rb);
+// 	user_ring_buffer__free(user_rb);
+
+// 	bpf_link__destroy(link);
+// 	UEI_REPORT(skel, uei);
+// 	scx_serialise__destroy(skel);
+// 	return 0;
+// }

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -24,8 +24,8 @@ const char help_fmt[] =
 	"  -s            Enter seed for the RNG. Default: 0xdeadbeef.\n"
 	"  -d            Enter depth of bug to search for. Default: 3.\n"
 	"  -h            Display this help and exit\n"
-	"  -r            Use random walk instead of PCT. 1 for random walk, 2 for random walk 2\n"
-	"  -u            Use udelay. 0 for no, 1 for yes. Default: 1.\n";
+	"  -r            (PCT disabled) 1 for random priority walk, 2 for random walk 2, Default: 2. \n"
+	"  -u            Use udelay. 0 for no, 1 for yes. (Deprecated) Default: 0.\n";
 
 static volatile int exit_req;
 

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -36,7 +36,7 @@ typedef struct {
 	pthread_cond_t cond;
 	int available;
 	int num_call;
-	u32 rng_state;
+	u32 rng_seed;
 	unsigned long long pid;
 } sched_shm;
 
@@ -110,7 +110,7 @@ static int send_sched_req(struct user_ring_buffer *ringbuf)
 
 	req->num_call = shm_ptr->num_call;
 	req->pid = shm_ptr->pid;
-	req->rng_seed = 999;
+	req->rng_seed = shm_ptr->rng_seed;
 	user_ring_buffer__submit(ringbuf, req);
 	printf("[send_sched_req] sched request has been sent\n");
 	return 0;
@@ -210,12 +210,15 @@ int main(int argc, char **argv)
 				printf("use random walk: %lu\n", v);
 				skel->rodata->use_pct = 0;
 
-				if (v == 1)
+				if (v == 1) {
+					skel->rodata->use_random_priority_walk = 1;
+					skel->rodata->use_random_walk = 0;
+				} else if (v == 2) {
+					skel->rodata->use_random_priority_walk = 0;
 					skel->rodata->use_random_walk = 1;
-				else if (v == 2)
-					skel->rodata->use_random_walk_2 = 1;
-				else
+				} else {
 					SCX_BUG_ON(1, "Invalid option for -r");
+				}
 			}
 			break;
 		case 'u':

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -144,6 +144,19 @@ static void read_stats(struct scx_serialise *skel, __u64 *stats)
 	}
 }
 
+void* stats_thread_loop(void* args) {
+	struct scx_serialise* skel = (struct scx_serialise*) args;
+
+	while (!exit_req && !UEI_EXITED(skel, uei)) {
+		__u64 stats[2];
+		read_stats(skel, stats);
+		printf("main=%llu thread=%llu\n", stats[0], stats[1]);
+		fflush(stdout);
+		sleep(1);
+	}
+	return NULL;
+}
+
 int main(int argc, char **argv)
 {
 	struct scx_serialise *skel;
@@ -239,13 +252,13 @@ int main(int argc, char **argv)
 	}
 
 
-	// while (!exit_req && !UEI_EXITED(skel, uei)) {
-	// 	__u64 stats[2];
-	// 	read_stats(skel, stats);
-	// 	printf("main=%llu thread=%llu\n", stats[0], stats[1]);
-	// 	fflush(stdout);
-	// 	sleep(1);
-	// }
+  pthread_t stats_thread;
+
+  // Create the thread
+  if (pthread_create(&stats_thread, NULL, stats_thread_loop, (void *)skel) != 0) {
+      perror("Failed to create thread");
+      return 1;
+  }
 
 	
 	while (!exit_req && !UEI_EXITED(skel, uei)) {

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -36,6 +36,7 @@ typedef struct {
 	pthread_cond_t cond;
 	int available;
 	int num_call;
+	u32 rng_state;
 	unsigned long long pid;
 } sched_shm;
 
@@ -109,6 +110,7 @@ static int send_sched_req(struct user_ring_buffer *ringbuf)
 
 	req->num_call = shm_ptr->num_call;
 	req->pid = shm_ptr->pid;
+	req->rng_seed = 999;
 	user_ring_buffer__submit(ringbuf, req);
 	printf("[send_sched_req] sched request has been sent\n");
 	return 0;

--- a/tools/sched_ext/scx_simple_signal.c
+++ b/tools/sched_ext/scx_simple_signal.c
@@ -139,17 +139,22 @@ int main(int argc, char **argv)
 	}
 
 	while (!exit_req && !UEI_EXITED(skel, uei)) {
+		fprintf(stderr, "Acquiring SHM mutex...\n");
 		pthread_mutex_lock(&shm_ptr->mutex);
 
+		fprintf(stderr, "Waiting for signal from executor\n");
 		// wait for the request from executor
 		while (!shm_ptr->available) {
 			pthread_cond_wait(&shm_ptr->cond, &shm_ptr->mutex);
+			fprintf(stderr, "woke\n");
 		}
+		fprintf(stderr, "Received signal from executor!\n");
 
 		if (send_sched_req(user_rb) < 0) {
 			fprintf(stderr, "Failed to send request to user_ring_buffer\n");
 			break;
 		}
+		fprintf(stderr, "Sent signal to EBPF prog via ringbuffer\n");
 
 		// keep waiting
 		err = ring_buffer__poll(rb, -1);
@@ -165,6 +170,7 @@ int main(int argc, char **argv)
 		shm_ptr->available = 0;
 
 		pthread_mutex_unlock(&shm_ptr->mutex);
+		fprintf(stderr, "Relinquished SHM mutex...\n");
 	}
 
 cleanup:

--- a/tools/sched_ext/scx_simple_signal.h
+++ b/tools/sched_ext/scx_simple_signal.h
@@ -12,4 +12,8 @@ struct sched_req {
     int num_call;
 };
 
+struct xorshift32_state {
+       u32 a;
+};
+
 #endif /* __BOOTSTRAP_H */

--- a/tools/sched_ext/scx_simple_signal.h
+++ b/tools/sched_ext/scx_simple_signal.h
@@ -9,7 +9,8 @@ struct event {
 
 struct sched_req {
 	int pid;
-    int num_call;
+  int num_call;
+  u32 rng_seed;
 };
 
 struct xorshift32_state {

--- a/tools/sched_ext/scx_simple_signal_cli.c
+++ b/tools/sched_ext/scx_simple_signal_cli.c
@@ -57,16 +57,17 @@ void setup_sched_shm()
 		fail("mmap shm_ptr fail");
 	}
 
-	pthread_mutexattr_t mutex_attr;
-  pthread_mutexattr_init(&mutex_attr);
-  pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
-  pthread_mutex_init(&shm_ptr->mutex, &mutex_attr);
-  pthread_condattr_t cond_attr;
-  pthread_condattr_init(&cond_attr);
-  pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
-  pthread_cond_init(&shm_ptr->cond, &cond_attr);
-  pthread_mutexattr_destroy(&mutex_attr);
-  pthread_condattr_destroy(&cond_attr);
+	fprintf(stderr, "noinit\n");
+	//  pthread_mutexattr_t mutex_attr;
+	//  pthread_mutexattr_init(&mutex_attr);
+	//  pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
+	//  pthread_mutex_init(&shm_ptr->mutex, &mutex_attr);
+	//  pthread_condattr_t cond_attr;
+	//  pthread_condattr_init(&cond_attr);
+	//  pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
+	//  pthread_cond_init(&shm_ptr->cond, &cond_attr);
+	//  pthread_mutexattr_destroy(&mutex_attr);
+	//  pthread_condattr_destroy(&cond_attr);
 }
 
 void send_sched_req()

--- a/tools/sched_ext/scx_simple_signal_cli.c
+++ b/tools/sched_ext/scx_simple_signal_cli.c
@@ -29,6 +29,7 @@ typedef struct {
 	pthread_cond_t cond;
 	int available;
 	int num_call;
+	u32 rng_state;
 	unsigned long long pid;
 } sched_shm;
 
@@ -79,6 +80,7 @@ void send_sched_req()
 	shm_ptr->available = 1;
 	shm_ptr->num_call = 1;
 	shm_ptr->pid = 100;
+	shm_ptr->rng_state = 999;
 	
 	pthread_cond_signal(&shm_ptr->cond);
 	debug("[send_sched_req] signaled cond wait\n");

--- a/tools/sched_ext/scx_simple_signal_cli.c
+++ b/tools/sched_ext/scx_simple_signal_cli.c
@@ -29,7 +29,7 @@ typedef struct {
 	pthread_cond_t cond;
 	int available;
 	int num_call;
-	u32 rng_state;
+	u32 rng_seed;
 	unsigned long long pid;
 } sched_shm;
 
@@ -80,7 +80,7 @@ void send_sched_req()
 	shm_ptr->available = 1;
 	shm_ptr->num_call = 1;
 	shm_ptr->pid = 100;
-	shm_ptr->rng_state = 999;
+	shm_ptr->rng_seed = 999;
 	
 	pthread_cond_signal(&shm_ptr->cond);
 	debug("[send_sched_req] signaled cond wait\n");

--- a/tools/sched_ext/scx_simple_signal_cli.c
+++ b/tools/sched_ext/scx_simple_signal_cli.c
@@ -1,0 +1,90 @@
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define SCHED_SHM "/sched_shared_memory"
+#define SHM_SIZE 1024
+
+bool debug = true;
+
+#define debug(fmt, args...)            \
+	do {                                 \
+		if (debug)                         \
+			fprintf(stderr, fmt, ##args);    \
+	} while (0)
+
+
+#define fail(fmt, args...)             \
+	do {                                 \
+		fprintf(stderr, fmt, ##args);      \
+		exit(1);                           \
+	} while (0)
+
+typedef struct {
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	int available;
+	int num_call;
+	unsigned long long pid;
+} sched_shm;
+
+static int schedShmFd;
+
+sched_shm *shm_ptr;
+
+static volatile int exit_req;
+
+static void sigint_handler(int simple)
+{
+	exit_req = 1;
+}
+
+void setup_sched_shm() 
+{
+	schedShmFd = shm_open(SCHED_SHM,  O_CREAT | O_RDWR, 0666);
+	if (schedShmFd < 0) {
+		fail("shm_open(SCHED_SHM,  O_CREAT | O_RDWR, 0666) fail");
+	}
+	if (ftruncate(schedShmFd, SHM_SIZE) < 0) {
+		fail("ftruncate(schedShmFd, SHM_SIZE) fail");
+	};
+	shm_ptr = (sched_shm*)mmap(0, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, schedShmFd, 0);
+	if (shm_ptr == MAP_FAILED) {
+		fail("mmap shm_ptr fail");
+	}
+
+	pthread_mutexattr_t mutex_attr;
+  pthread_mutexattr_init(&mutex_attr);
+  pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
+  pthread_mutex_init(&shm_ptr->mutex, &mutex_attr);
+  pthread_condattr_t cond_attr;
+  pthread_condattr_init(&cond_attr);
+  pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
+  pthread_cond_init(&shm_ptr->cond, &cond_attr);
+  pthread_mutexattr_destroy(&mutex_attr);
+  pthread_condattr_destroy(&cond_attr);
+}
+
+void send_sched_req()
+{
+	debug("[send_sched_req] sending sched requestion\n");
+	pthread_mutex_lock(&shm_ptr->mutex);
+	debug("[send_sched_req] acquired lock\n");
+	// send data here
+	shm_ptr->available = 1;
+	shm_ptr->num_call = 1;
+	shm_ptr->pid = 100;
+	
+	pthread_cond_signal(&shm_ptr->cond);
+	debug("[send_sched_req] signaled cond wait\n");
+	pthread_mutex_unlock(&shm_ptr->mutex);
+}
+
+int main() {
+  setup_sched_shm();
+  send_sched_req();
+}


### PR DESCRIPTION
Using trick from `scx_simple_signal` to allow the scheduler RNG to be reset on a message sent from user-space

Also split out the scheduling algorithm code so that the main EBPF code is more concise

Note: the command line options for choosing an algorithm are broken. the default is random walk.