### PR TITLE
sched_update

### DIFF
--- a/tools/sched_ext/random-priority.c
+++ b/tools/sched_ext/random-priority.c
@@ -17,14 +17,10 @@ static inline int update_priorities_rp(pid_t pid)
 		     pid, priority);
 		return -1;
 	}
+	
+	update_priority(pid, priority);
 
-	/*
-	 * Update the task context.
-	 *
-	 * Since we cannot assure that the task should exist (as new tasks may
-	 * get enqueued), we set should_exist to false.
-	 */
-	tctx_map_insert(pid, priority, true, false);
+	return 0;
 }
 
 static inline s32 init_rp() {

--- a/tools/sched_ext/random-priority.c
+++ b/tools/sched_ext/random-priority.c
@@ -13,7 +13,7 @@ static inline int update_priorities_rp(pid_t pid)
 	dbg("prio new %d", priority);
 
 	if (priority < 0) {
-		warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
+		bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
 		     pid, priority);
 		return -1;
 	}

--- a/tools/sched_ext/random-priority.c
+++ b/tools/sched_ext/random-priority.c
@@ -10,7 +10,7 @@
 static inline int update_priorities_rp(pid_t pid)
 {
 	s32 priority = xorshift32(&rng_state) % 2147483647;
-	dbg("prio new %d", priority);
+	dbg("[update_priorities_rp] prio new %d", priority);
 
 	if (priority < 0) {
 		bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",

--- a/tools/sched_ext/random-walk.c
+++ b/tools/sched_ext/random-walk.c
@@ -38,7 +38,7 @@ static s32 update_priorities_rw(pid_t pid) {
 		s32 priority = assign_rw_priority();
 
 		if (priority < 0) {
-			warn("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
+			bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
 			     pid, priority);
 			return -1;
 		}

--- a/tools/sched_ext/random-walk.c
+++ b/tools/sched_ext/random-walk.c
@@ -18,46 +18,26 @@ static inline s32 assign_rw_priority()
 /*
  * Callback function to update all priorities in tctx_map for random_walk_2
  */
-static __u64 update_all_prios(struct bpf_map *map, pid_t *key,
+static int update_all_prios(struct bpf_map *map, pid_t *pid,
 			      struct task_ctx *tctx,
 			      struct tctx_callback_ctx *tcallbackctx)
 {
-	/* Use highest_priority_pid to indicate the pid of the task we have already updated */
-	pid_t pid_to_avoid = tcallbackctx->highest_priority_pid;
-	s32 new_priority;
-	if (*key != pid_to_avoid) {
-		new_priority = assign_rw_priority();
-		bpf_spin_lock(&tctx->lock);
-		tctx->priority = new_priority;
-		bpf_spin_unlock(&tctx->lock);
-	}
+	if (tctx->eid != tcallbackctx->eid)
+		return 0;
+	
+	s32 priority = assign_rw_priority();
+	update_priority(*pid, priority);
 	return 0;
 }
 
-static s32 update_priorities_rw(pid_t pid) {
-		s32 priority = assign_rw_priority();
+static s32 update_priorities_rw(u32 eid) {
+	/* Update the priorities of all threads */
+	struct tctx_callback_ctx tcallbackctx = {
+		.eid = eid
+	};
 
-		if (priority < 0) {
-			bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",
-			     pid, priority);
-			return -1;
-		}
-
-		/*
-		 * Update the task context.
-		 *
-		 * Since we cannot assure that the task should exist (as new tasks may
-		 * get enqueued), we set should_exist to false.
-		 */
-		tctx_map_insert(pid, priority, true, false);
-
-		/* Update the priorities of all threads */
-		struct tctx_callback_ctx tcallbackctx = {
-			.highest_priority_pid = pid,
-		};
-
-		bpf_for_each_map_elem(&task_ctx_map, update_all_prios,
-				      &tcallbackctx, 0);
+	bpf_for_each_map_elem(&task_ctx_map, update_all_prios,
+		&tcallbackctx, 0);
 
 		return 0;
 }

--- a/tools/sched_ext/random-walk.c
+++ b/tools/sched_ext/random-walk.c
@@ -10,7 +10,7 @@
 static inline s32 assign_rw_priority()
 {
 	s32 priority = xorshift32(&rng_state) % 2147483647;
-	dbg("prio new %d", priority);
+	// dbg("[assign_rw_priority] prio new %d", priority);
 	return priority;
 }
 
@@ -26,6 +26,7 @@ static int update_all_prios(struct bpf_map *map, pid_t *pid,
 		return 0;
 	
 	s32 priority = assign_rw_priority();
+	// bpf_printk("[update_all_prios] pid: %d, priority: %d", *pid, priority);
 	update_priority(*pid, priority);
 	return 0;
 }
@@ -39,7 +40,7 @@ static s32 update_priorities_rw(u32 eid) {
 	bpf_for_each_map_elem(&task_ctx_map, update_all_prios,
 		&tcallbackctx, 0);
 
-		return 0;
+	return 0;
 }
 
 static inline s32 init_rw() {

--- a/tools/sched_ext/scx_scheduling_algorithms.c
+++ b/tools/sched_ext/scx_scheduling_algorithms.c
@@ -14,16 +14,22 @@ u32 iterations, initial_max_num_events, task_count, max_num_events,
 #include "random-walk.c"
 #include "random-priority.c"
 
-s32 update_priorities(pid_t pid) {
+s32 assign_priority(pid_t pid) {
+	s32 priority;
+	
 	if (use_pct) {
-		return update_priorities_pct(pid);
+		priority = assign_pct_priority(pid);
 	} else if (use_random_walk) {
-		return update_priorities_rw(pid);			
+		priority = assign_rw_priority();		
 	} else if (use_random_priority_walk) {
-		return update_priorities_rp(pid);
+		priority = assign_priorities_rp();
+	}
+	if (priority < 0) {
+		bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",pid, priority);
+		return -1;
 	}
 
-	return -1;
+	return priority;
 }
 
 int init_scheduling_algo() {

--- a/tools/sched_ext/scx_scheduling_algorithms.c
+++ b/tools/sched_ext/scx_scheduling_algorithms.c
@@ -12,9 +12,9 @@ u32 iterations, initial_max_num_events, task_count, max_num_events,
 
 // #include "pct.c"
 #include "random-walk.c"
-// #include "random-priority.c"
+#include "random-priority.c"
 
-void update_priorities(u32 eid) {
+void update_priorities(pid_t pid, u32 eid) {
 	// if (use_pct) {
 	// 	update_priorities_pct(eid);
 	// } else if (use_random_walk) {
@@ -23,7 +23,11 @@ void update_priorities(u32 eid) {
 	// 	update_priorities_rp(eid);
 	// }
 
-	update_priorities_rw(eid);
+	if (use_random_walk) {
+		update_priorities_rw(eid);			
+	} else if (use_random_priority_walk) {
+		update_priorities_rp(pid);
+	}
 }
 
 int init_scheduling_algo() {
@@ -35,5 +39,9 @@ int init_scheduling_algo() {
 	// 	return init_rp();
 	// }
 	
-	return init_rw();
+	if (use_random_walk) {
+		return init_rw();			
+	} else if (use_random_priority_walk) {
+		return init_rp();
+	}
 }

--- a/tools/sched_ext/scx_scheduling_algorithms.c
+++ b/tools/sched_ext/scx_scheduling_algorithms.c
@@ -10,36 +10,30 @@
 u32 iterations, initial_max_num_events, task_count, max_num_events,
 	num_events;
 
-#include "pct.c"
+// #include "pct.c"
 #include "random-walk.c"
-#include "random-priority.c"
+// #include "random-priority.c"
 
-s32 assign_priority(pid_t pid) {
-	s32 priority;
-	
-	if (use_pct) {
-		priority = assign_pct_priority(pid);
-	} else if (use_random_walk) {
-		priority = assign_rw_priority();		
-	} else if (use_random_priority_walk) {
-		priority = assign_priorities_rp();
-	}
-	if (priority < 0) {
-		bpf_printk("[enqueue] failed to assign priority for pid: %d, priority: %d\n",pid, priority);
-		return -1;
-	}
+void update_priorities(u32 eid) {
+	// if (use_pct) {
+	// 	update_priorities_pct(eid);
+	// } else if (use_random_walk) {
+	// 	update_priorities_rw(eid);			
+	// } else if (use_random_priority_walk) {
+	// 	update_priorities_rp(eid);
+	// }
 
-	return priority;
+	update_priorities_rw(eid);
 }
 
 int init_scheduling_algo() {
-	if (use_pct) {
-		return init_pct();
-	} else if (use_random_walk) {
-		return init_rw();			
-	} else if (use_random_priority_walk) {
-		return init_rp();
-	}
-
-	return -1;
+	// if (use_pct) {
+	// 	return init_pct();
+	// } else if (use_random_walk) {
+	// 	return init_rw();			
+	// } else if (use_random_priority_walk) {
+	// 	return init_rp();
+	// }
+	
+	return init_rw();
 }

--- a/tools/sched_ext/scx_scheduling_algorithms.c
+++ b/tools/sched_ext/scx_scheduling_algorithms.c
@@ -25,7 +25,7 @@ void update_priorities(pid_t pid, u32 eid) {
 
 	if (use_random_walk) {
 		update_priorities_rw(eid);			
-	} else if (use_random_priority_walk) {
+	} else if (use_random_priority_walk && pid > 0) {
 		update_priorities_rp(pid);
 	}
 }
@@ -44,4 +44,5 @@ int init_scheduling_algo() {
 	} else if (use_random_priority_walk) {
 		return init_rp();
 	}
+	return 0;
 }

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -58,13 +58,7 @@ static void sigint_handler(int simple)
 //     return (rand() % (max_num - min_num + 1)) + min_num;
 // }
 
-void get_current_time_in_milliseconds() {
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
 
-    long long current_time = ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
-	printf("current time: %lld\n", current_time);
-}
 
 static void setup_shm()
 {
@@ -221,7 +215,6 @@ int main(int argc, char **argv)
 			fprintf(stderr, "woke\n");
 		}
 		fprintf(stderr, "Received signal from executor!\n");
-		get_current_time_in_milliseconds();
 
 		if (send_sched_req(user_rb) < 0) {
 			fprintf(stderr, "Failed to send request to user_ring_buffer\n");
@@ -230,7 +223,6 @@ int main(int argc, char **argv)
 			break;
 		}
 		fprintf(stderr, "Sent signal to EBPF prog via ringbuffer\n");
-		get_current_time_in_milliseconds();
 
 		// // keep waiting
 		// err = ring_buffer__poll(rb, -1);

--- a/tools/sched_ext/scx_serialise.c
+++ b/tools/sched_ext/scx_serialise.c
@@ -11,7 +11,7 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include "scx_simple_signal.h"
+#include "scx_serialise.h"
 #include "scx_serialise.bpf.skel.h"
 
 const char help_fmt[] =

--- a/tools/sched_ext/scx_serialise.h
+++ b/tools/sched_ext/scx_serialise.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2020 Facebook */
+#ifndef __BOOTSTRAP_H
+#define __BOOTSTRAP_H
+
+struct event {
+	int pid;
+};
+
+struct sched_req {
+	int pid;
+  int num_call;
+  u32 rng_seed;
+};
+
+struct xorshift32_state {
+       u32 a;
+};
+
+#endif /* __BOOTSTRAP_H */


### PR DESCRIPTION
`serialise_enqueue`: for tasks using the SCHED_EXT policy, it calls `handle_sched_ext()` to manage the task’s scheduling process, including updating the task context and managing task priorities. If the task does not use SCHED_EXT, it is dispatched immediately.
`serialise_dispatch` dequeues a task group, determines the highest priority task within the group, and dispatches that task to the CPU for execution.